### PR TITLE
xen: call xen-init-dom0 instead of re-implementing part of it

### DIFF
--- a/srcpkgs/xen/files/xen/run
+++ b/srcpkgs/xen/files/xen/run
@@ -1,6 +1,5 @@
 #!/bin/sh
 exec 2>&1
 sv check xenconsoled >/dev/null || exit 1
-xenstore-write "/local/domain/0/domid" 0 || exit 1
-xenstore-write "/local/domain/0/name" "Domain-0" || exit 1
+/usr/lib/xen/bin/xen-init-dom0 || exit 1
 exec chpst -b xen pause


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Description

After a few hours of debugging a xen dom0 setup I ended up at this being the issue.

I was getting
`libxl_set_memory_target: unable to retrieve domain configuration: No such file or directory` from running `xl create ...`.
Delving through the xen source, I saw that the error was coming from `tools/libxl/libxl_mem.c` line 202, which in turn was reporting an error from the `libxl__get_domain_configuration` function in `xen/tools/libxl/libxl_internal.c`, which in turn could be reporting from `libxl__userdata_retrieve` or `libxl_domain_config_from_json`. But if the `libxl__userdata_retrieve` function fails it emits a log message I wasn't seeing, so it had to be `libxl_domain_config_from_json`.

I had also noticed that the docs from various sources were mentioning a xen-init-dom0 one-shot "service" I wasn't seeing implemented here; but running xen-init-dom0 says dom0 was already initialized.  tools/helpers/xen-init-dom0.c in the source tree references a `gen_stub_json_config`; so I came to the conclusion that the "xen" service here was partially initializing dom0, not creating the necessary json config, and causing `libxl_domain_config_from_json` to fail.

Implementing this change and rebooting fixed the issue.